### PR TITLE
Add button to storybook

### DIFF
--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/react";
+import "../src/index.css";
 
 const preview: Preview = {
   parameters: {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ function App() {
           Retrofuture component library
         </h1>
         <br />
-        <Button />
+        <Button text="Button Text" />
       </div>
     </div>
   );

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-function MyButton() {
+function MyButton({ text = "Button" }: { text: string }) {
     return (
         <div className="relative inline-block">
             {/* Button content */}
             <button className="relative z-10 py-2 px-6 font-bold text-white bg-neonSunset transform skew-x-[30deg] hover:bg-electricDream hover:shadow-lg transition-all">
-                <span className="inline-block transform -skew-x-[30deg]">Button</span>
+                <span className="inline-block transform -skew-x-[30deg]">{text}</span>
             </button>
         </div>
     );

--- a/frontend/src/components/stories/Button.stories.ts
+++ b/frontend/src/components/stories/Button.stories.ts
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+
+import Button from "../Button";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: "Components/Button",
+  component: Button,
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    layout: "centered",
+  },
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  argTypes: {},
+  // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+  args: { onClick: fn() },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Primary: Story = {
+  args: {
+    text: "Cool",
+    label: "Button",
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    label: "Button",
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: "large",
+    label: "Button",
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: "small",
+    label: "Button",
+  },
+};
+
+export const TestStory: Story = {
+  args: {
+    primary: false,
+    label: "Button",
+  },
+};


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add button component to Storybook with text prop and integrate into App.
> 
>   - **Button Component**:
>     - Updated `MyButton` in `Button.tsx` to accept a `text` prop, defaulting to "Button".
>     - Modified button rendering to display `text` prop.
>   - **App Integration**:
>     - Updated `App.tsx` to use `Button` with `text="Button Text"`.
>   - **Storybook**:
>     - Added `Button.stories.ts` to define stories for `Button` with various configurations.
>     - Imported `index.css` in `preview.ts` for global styles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Fretro-comp-library&utm_source=github&utm_medium=referral)<sup> for dddee3e2db4e18f9463fe1038da5287d9773d0fe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->