### PR TITLE
added basic accordion

### DIFF
--- a/frontend/src/components/TrizoidAccordion.tsx
+++ b/frontend/src/components/TrizoidAccordion.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import TransformingButton from './TransformingButton';
+
+interface AccordionItem {
+  title: string;
+  content: string;
+}
+
+interface TrizoidAccordionProps {
+  items: AccordionItem[];
+}
+
+const TrizoidAccordion: React.FC<TrizoidAccordionProps> = ({ items }) => {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [spacing, setSpacing] = useState<number>(0);
+
+  useEffect(() => {
+    // Calculate the spacing based on TransformingButton's geometry
+    const baseWidth = 2.5 * parseFloat(getComputedStyle(document.documentElement).fontSize);
+    const height = baseWidth * Math.sqrt(3);
+        console.log(height)
+    
+    // Calculate the visual spacing that matches the horizontal overlap
+    // This is approximately *(.37) of the height, which creates a visual balance
+    //this needs to be refactored to compute 
+    const calculatedSpacing = height * 0.37;
+    
+    setSpacing(calculatedSpacing);
+  }, []);
+
+  const toggleItem = (index: number) => {
+    setActiveIndex(activeIndex === index ? null : index);
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto">
+      {items.map((item, index) => (
+        <div key={index} style={{ marginBottom: `${spacing}px` }}>
+          <div onClick={() => toggleItem(index)} className="cursor-pointer">
+            <TransformingButton
+              leftInput={item.title}
+              rightInput={activeIndex === index ? '▲' : '▼'}
+            />
+          </div>
+          {activeIndex === index && (
+            <div className="p-4 bg-gray-100 rounded-b-lg transition-all duration-300 ease-in-out">
+              {item.content}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TrizoidAccordion;

--- a/frontend/src/components/stories/TrizoidAccordion.stories.ts
+++ b/frontend/src/components/stories/TrizoidAccordion.stories.ts
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import TrizoidAccordion from "../TrizoidAccordion";
+
+const meta = {
+  title: "Components/TrizoidAccordion",
+  component: TrizoidAccordion,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    items: { control: "object" },
+  },
+} satisfies Meta<typeof TrizoidAccordion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    items: [
+      { title: "Section 1", content: "Content for section 1" },
+      { title: "Section 2", content: "Content for section 2" },
+      { title: "Section 3", content: "Content for section 3" },
+    ],
+  },
+};
+
+export const ManyItems: Story = {
+  args: {
+    items: [
+      { title: "Section 1", content: "Content for section 1" },
+      { title: "Section 2", content: "Content for section 2" },
+      { title: "Section 3", content: "Content for section 3" },
+      { title: "Section 4", content: "Content for section 4" },
+      { title: "Section 5", content: "Content for section 5" },
+    ],
+  },
+};


### PR DESCRIPTION
the vertical spacing multiple parameter is fudged for a decent visual spacing rn, needs to be recomputed with new functionally contained math that recomputes the apparent spacing between the triangles(which are made to overlap with a computed negative margin) to then recapitulate the value which is the chord distance between the two inversely juxtaposed triangle/trapezoid 30deg diagonal edges, then make that the vertical spacing value
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `TrizoidAccordion` component with Storybook stories, featuring calculated spacing and toggle functionality.
> 
>   - **Component**:
>     - Added `TrizoidAccordion` in `TrizoidAccordion.tsx` with props for `items`.
>     - Uses `useState` for `activeIndex` and `spacing`, and `useEffect` to calculate spacing.
>     - Spacing calculation based on `TransformingButton` geometry, currently hardcoded.
>   - **Storybook**:
>     - Added `TrizoidAccordion.stories.ts` with `Default` and `ManyItems` stories.
>     - Stories demonstrate accordion with varying numbers of sections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fractal-bootcamp%2Fretro-comp-library&utm_source=github&utm_medium=referral)<sup> for fddb08428973ab304454b64e70091c62ff1f1a44. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->